### PR TITLE
Omit Tier parameter if not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ tier: Standard
 ## Limitations
 This plugin works only if exactly one apiKey is specified.
 
+Use of `tier` attribute requires aws-sdk 2.442.0 or higher.
+
 Requirements and constraints of parameter names page by AWS: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html
 
 ## Contributing

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -16,8 +16,6 @@ const getApiKey = (serverless) => {
 const getTier = (service) => {
     if (hasConfigProperty(service, 'tier')) {
         return service.custom.apiKeyParam.tier;
-    } else {
-        return 'Standard';
     }
 };
 

--- a/src/paramsStore.js
+++ b/src/paramsStore.js
@@ -22,11 +22,14 @@ const uploadParam = (putParameter, addTagsToResource, getParameter, logger) =>
             Value: apiKey,
             Description: paramDescription,
             Overwrite: true,
-            Tier: tier
         };
 
         if (kmsKeyId) {
             newParameterParams.KeyId = kmsKeyId;
+        }
+
+        if (tier) {
+            newParameterParams.Tier = tier;
         }
 
         await putParameter(newParameterParams);


### PR DESCRIPTION
Add support for older versions of aws-sdk

Fixes #3 